### PR TITLE
Task/cmp 4274

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,11 @@ src/GlobalAssemblyInfo.cs
 src/Mixpanel.NET/packages
 src/Mixpanel.NET/packages
 src/Mixpanel.NET/packages
+/src/Workshare.Mixpanel.NET/Acknowledgments.txt
+/src/Workshare.Mixpanel.NET/InstalledPackages.json
+/src/Workshare.Mixpanel.NET/Litera.Agreements.Generator/
+/src/Workshare.Mixpanel.NET/oss_request.txt
+/src/Workshare.Mixpanel.NET/oss_used.json
+/src/Workshare.Mixpanel.NET/Third-Party License Agreements.rtf
+/src/Workshare.Mixpanel.NET/Third-Party License Agreements.txt
+/VersionNumber.txt

--- a/bld/build.ps1
+++ b/bld/build.ps1
@@ -159,6 +159,7 @@ Task Run-Agreement-Tool {
 	pushd .
 	cd "$dir_source\Workshare.Mixpanel.NET"
 	Exec {
+		AddMsBuildPathIfNecessary
 		&nuget install Litera.Agreements.Generator -o . -excludeversion
 		&$dotnetExe Litera.Agreements.Generator\tools\Litera.Agreements.Generator.dll -p "Mixpanel.NET" -d "..\Mixpanel.NET" -o .
 	}
@@ -167,6 +168,7 @@ Task Run-Agreement-Tool {
 }
 
 Task Get-Dependencies {
+	AddMsBuildPathIfNecessary
 	& nuget restore $solution
 }
 

--- a/bld/msbuild-util.ps1
+++ b/bld/msbuild-util.ps1
@@ -1,7 +1,17 @@
 
 ### MSBUILD FUNCTIONS ####
 
-$msbuildExe = "C:\Program Files (x86)\MSBuild\14.0\Bin\msbuild.exe"
+function Get-MsBuildExe {
+
+    $msbuild = vswhere -latest -property installationPath
+    if($msbuild.Contains("2019")){
+        $msbuild = Join-Path $msbuild "MSBuild\Current\Bin\msbuild.exe"
+    }
+    else {
+        $msbuild = Join-Path $msbuild "MSBuild\15.0\Bin\msbuild.exe"
+    }
+    return $msbuild
+}
 
 function Clean-Solution
 {
@@ -9,6 +19,7 @@ function Clean-Solution
         [string] $solutionPath,
         [string] $configuration
     )   
+    $msbuildExe = Get-MsBuildExe
     Exec { &$msbuildExe $solutionPath /t:Clean /nr:false /clp:ErrorsOnly /m /p:Configuration="$configuration" /nologo }
 }
 
@@ -31,7 +42,6 @@ function Build-Project
         $extraArgs += $param
     }
     
-    Exec { 
-        &$msbuildExe $path /t:Build /clp:ErrorsOnly /nr:false /p:Platform="$platform" /m /p:Configuration="$configuration" $extraArgs /nologo
-    }
+    $msbuildExe = Get-MsBuildExe
+    Exec { &$msbuildExe $path /t:Build /clp:ErrorsOnly /nr:false /p:Platform="$platform" /m /p:Configuration="$configuration" $extraArgs /nologo }
 }

--- a/bld/msbuild-util.ps1
+++ b/bld/msbuild-util.ps1
@@ -22,7 +22,6 @@ function Build-Project
         [array] $buildProperties
     )   
 
-    tskill nunit-agent
     Stop-Process -name nunit-agent -ErrorAction Continue
 
     $extraArgs = @()

--- a/bld/msbuild-util.ps1
+++ b/bld/msbuild-util.ps1
@@ -1,6 +1,18 @@
 
 ### MSBUILD FUNCTIONS ####
 
+function Get-MsBuildPath {
+
+    $msbuildPath = vswhere -latest -property installationPath
+    if($msbuildPath.Contains("2019")){
+        $msbuildPath = Join-Path $msbuildPath "MSBuild\Current\Bin\"
+    }
+    else {
+        $msbuildPath = Join-Path $msbuildPath "MSBuild\15.0\Bin\"
+    }
+    return $msbuildPath
+}
+ 
 function Get-MsBuildExe {
 
     $msbuild = vswhere -latest -property installationPath
@@ -11,6 +23,17 @@ function Get-MsBuildExe {
         $msbuild = Join-Path $msbuild "MSBuild\15.0\Bin\msbuild.exe"
     }
     return $msbuild
+}
+
+function AddMsBuildPathIfNecessary {
+	
+	$msbuildPath = Get-MsBuildPath
+
+	if (!$env:PATH.StartsWith($msbuildPath))
+	{
+		Write-Output "Adding msbuild path to the beginning of path"
+		$env:PATH = "$msbuildPath;$env:PATH"
+	}
 }
 
 function Clean-Solution

--- a/bld/msbuild-util.ps1
+++ b/bld/msbuild-util.ps1
@@ -23,6 +23,7 @@ function Build-Project
     )   
 
     tskill nunit-agent
+    Stop-Process -name nunit-agent -ErrorAction Continue
 
     $extraArgs = @()
 


### PR DESCRIPTION
When calling psake from another powershell script, the tskill fails and stops the script, so change tskill to Stop-Process -ErrorAction Continue.

Psake inserts the msbuild 4 directory at the beginning of the path so when we call Nuget from psake it uses the old msbuild to do the nuget restore but the old msbuild doesn't understand VSS_NUGET_EXTERNAL_FEED_ENDPOINTS so the script hangs. So we put the appropriate msbuild path into the PATH env var in front of the old msbuild path.